### PR TITLE
now,  we can get upstream servers status through "one" http interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,29 +26,22 @@ https://github.com/zhouchangxun/ngx_healthcheck_module/blob/master/nginx.conf.ex
 
 # demo output(use example conf above)
 ``` python
-[root@test2 ngx_healthcheck_module]# 
-[root@test2 ngx_healthcheck_module]# curl localhost/status?format=json
+root@changxun-PC:~/nginx-dev/ngx_healthcheck_module# curl localhost/status
 {"servers": {
-  "total": 2,
-  "generation": 1,
-  "server": [
-    {"index": 0, "upstream": "http-cluster", "name": "127.0.0.1:8080", "status": "up", "rise": 7, "fall": 0, "type": "http", "port": 0},
-    {"index": 1, "upstream": "http-cluster", "name": "127.0.0.2:81", "status": "down", "rise": 0, "fall": 7, "type": "http", "port": 0}
-  ]
-}}
-[root@test2 ngx_healthcheck_module]# curl localhost/status/stream?format=json
-{"servers": {
-  "total": 4,
-  "generation": 1,
-  "server": [
-    {"index": 0, "upstream": "tcp-cluster", "name": "127.0.0.1:22", "status": "up", "rise": 9, "fall": 0, "type": "tcp", "port": 0},
-    {"index": 1, "upstream": "tcp-cluster", "name": "192.168.0.2:22", "status": "down", "rise": 0, "fall": 6, "type": "tcp", "port": 0},
-    {"index": 2, "upstream": "udp-cluster", "name": "127.0.0.1:53", "status": "down", "rise": 0, "fall": 10, "type": "udp", "port": 0},
+  "total": 6,
+  "generation": 3,
+  "http": [
+    {"index": 0, "upstream": "http-cluster", "name": "127.0.0.1:8080", "status": "up", "rise": 119, "fall": 0, "type": "http", "port": 0},
+    {"index": 1, "upstream": "http-cluster", "name": "127.0.0.2:81", "status": "down", "rise": 0, "fall": 120, "type": "http", "port": 0}
+  ],
+  "stream": [
+    {"index": 0, "upstream": "tcp-cluster", "name": "127.0.0.1:22", "status": "up", "rise": 22, "fall": 0, "type": "tcp", "port": 0},
+    {"index": 1, "upstream": "tcp-cluster", "name": "192.168.0.2:22", "status": "down", "rise": 0, "fall": 7, "type": "tcp", "port": 0},
+    {"index": 2, "upstream": "udp-cluster", "name": "127.0.0.1:53", "status": "down", "rise": 0, "fall": 120, "type": "udp", "port": 0},
     {"index": 3, "upstream": "udp-cluster", "name": "8.8.8.8:53", "status": "up", "rise": 3, "fall": 0, "type": "udp", "port": 0}
   ]
 }}
-[root@test2 ngx_healthcheck_module]# 
-
+root@changxun-PC:~/nginx-dev/ngx_healthcheck_module# 
 ```
 # directive
 
@@ -119,15 +112,9 @@ Context: http/upstream
 
 所有的后端服务器健康检查状态都存于共享内存中，该指令可以设置共享内存的大小。默认是1M，如果你有1千台以上的服务器并在配置的时候出现了错误，就可能需要扩大该内存的大小。
 
-Syntax: check_status [html|csv|json]
+Syntax: healthcheck_status [html|csv|json]
 
-Default: check_status html
-
-Context: http/server/location
-
-Syntax: l4check_status [html|csv|json]
-
-Default: l4check_status html
+Default: healthcheck_status html
 
 Context: http/server/location
 

--- a/common.h.in
+++ b/common.h.in
@@ -1,0 +1,133 @@
+
+/* module internal common header */
+
+#include <nginx.h>
+#include <ngx_core.h>
+
+
+typedef struct ngx_stream_upstream_check_peer_s ngx_stream_upstream_check_peer_t;
+typedef struct ngx_stream_upstream_check_srv_conf_s ngx_stream_upstream_check_srv_conf_t;
+
+typedef ngx_int_t (*ngx_stream_upstream_check_packet_init_pt)
+        (ngx_stream_upstream_check_peer_t *peer);
+typedef ngx_int_t (*ngx_stream_upstream_check_packet_parse_pt)
+        (ngx_stream_upstream_check_peer_t *peer);
+typedef void (*ngx_stream_upstream_check_packet_clean_pt)
+        (ngx_stream_upstream_check_peer_t *peer);
+
+
+typedef struct {
+    ngx_uint_t                               type;
+
+    ngx_str_t                                name;
+
+    ngx_str_t                                default_send;
+
+    /* HTTP */
+    ngx_uint_t                               default_status_alive;
+
+    ngx_event_handler_pt                     send_handler;
+    ngx_event_handler_pt                     recv_handler;
+
+    ngx_stream_upstream_check_packet_init_pt   init;
+    ngx_stream_upstream_check_packet_parse_pt  parse;
+    ngx_stream_upstream_check_packet_clean_pt  reinit;
+
+    unsigned need_pool;
+    unsigned need_keepalive;
+} ngx_check_conf_t;
+
+struct ngx_stream_upstream_check_srv_conf_s {
+    ngx_uint_t                               port;
+    ngx_uint_t                               fall_count;
+    ngx_uint_t                               rise_count;
+    ngx_msec_t                               check_interval;
+    ngx_msec_t                               check_timeout;
+    ngx_uint_t                               check_keepalive_requests;
+
+    ngx_check_conf_t                        *check_type_conf;
+    ngx_str_t                                send;
+
+    union {
+        ngx_uint_t                           return_code;
+        ngx_uint_t                           status_alive;
+    } code;
+    ngx_array_t                             *fastcgi_params; //only for http module.
+    ngx_uint_t                               default_down;
+};
+
+//ccc
+typedef struct {
+    ngx_shmtx_t                              mutex;
+#if (nginx_version >= 1002000)
+    ngx_shmtx_sh_t                           lock;
+#else
+    ngx_atomic_t                             lock;
+#endif
+
+    ngx_pid_t                                owner;
+
+    ngx_msec_t                               access_time;
+
+    ngx_uint_t                               fall_count;
+    ngx_uint_t                               rise_count;
+
+    ngx_uint_t                               busyness;
+    ngx_uint_t                               access_count;
+
+    struct sockaddr                         *sockaddr;
+    socklen_t                                socklen;
+
+    ngx_atomic_t                             down;          //current status.
+    ngx_str_t                               *upstream_name;
+    u_char                                   padding[64];
+} ngx_stream_upstream_check_peer_shm_t;
+
+//bbb
+typedef struct {
+    ngx_uint_t                               generation;// current process generation(==reload_num +1)
+    ngx_uint_t                               checksum;// we can know if peer config file changed by calculate it.
+    ngx_uint_t                               number;
+
+    /* ngx_stream_upstream_check_status_peer_t */
+    ngx_stream_upstream_check_peer_shm_t       peers[1]; //hack: peer[0]
+} ngx_stream_upstream_check_peers_shm_t; 
+     /* followed with (peers_num-1)*ngx_stream_upstream_check_peer_shm_t dynamicly,*/      
+    /* so we can ref by peers_shm->peers[0],[1],... */
+
+
+
+struct ngx_stream_upstream_check_peer_s {
+    ngx_flag_t                               state;
+    ngx_pool_t                              *pool;
+    ngx_uint_t                               index;
+    ngx_uint_t                               max_busy;
+    ngx_str_t                               *upstream_name;
+    ngx_addr_t                              *check_peer_addr;
+    ngx_addr_t                              *peer_addr;
+    ngx_event_t                              check_ev;
+    ngx_event_t                              check_timeout_ev;
+    ngx_peer_connection_t                    pc;
+
+    void                                    *check_data;
+    ngx_event_handler_pt                     send_handler;
+    ngx_event_handler_pt                     recv_handler;
+
+    ngx_stream_upstream_check_packet_init_pt   init; //zhoucx: function ptr
+    ngx_stream_upstream_check_packet_parse_pt  parse;
+    ngx_stream_upstream_check_packet_clean_pt  reinit;
+
+    ngx_stream_upstream_check_peer_shm_t      *shm;
+    ngx_stream_upstream_check_srv_conf_t      *conf;
+};
+
+//aaa
+typedef struct {
+    ngx_str_t                                check_shm_name;
+    ngx_uint_t                               checksum;
+    /* peers include ngx_stream_upstream_check_peer_t item*/
+    ngx_array_t                              peers;
+    ngx_stream_upstream_check_peers_shm_t     *peers_shm;
+} ngx_stream_upstream_check_peers_t;
+
+

--- a/nginx.conf.example
+++ b/nginx.conf.example
@@ -11,11 +11,8 @@ http {
     server {
         listen 80;
         # status interface
-        location /status/stream {
-            l4check_status;
-        }
         location /status {
-            check_status;
+            healthcheck_status;
         }
         # http front
         location / { 

--- a/ngx_healthcheck_status.c
+++ b/ngx_healthcheck_status.c
@@ -11,7 +11,7 @@
 
 #include "ngx_stream_upstream_check_module.h"
 
-/* inf different c source file, type declare can duplicate. :) */
+/* in different c source file, type declare can duplicate. :) */
 
 typedef struct ngx_stream_upstream_check_peer_s ngx_stream_upstream_check_peer_t;
 typedef struct ngx_stream_upstream_check_srv_conf_s ngx_stream_upstream_check_srv_conf_t;
@@ -178,8 +178,9 @@ typedef struct {
 
 
 // external var declare
-  ngx_uint_t ngx_stream_upstream_check_shm_generation ; //reload counter
-  ngx_stream_upstream_check_peers_t *check_peers_ctx ;  //stream peers data
+  extern ngx_uint_t ngx_stream_upstream_check_shm_generation ; //reload counter
+  extern ngx_stream_upstream_check_peers_t *stream_peers_ctx ;  //stream peers data
+  //extern ngx_http_upstream_check_peers_t *http_peers_ctx ; // http peers data
 
 
 //begin check_status function declare
@@ -385,7 +386,7 @@ ngx_stream_upstream_check_status_handler(ngx_http_request_t *r)
         }
     }
 
-    peers = check_peers_ctx; // status data provided by stream_upstream_health_check_module.
+    peers = stream_peers_ctx; // status data provided by stream_upstream_health_check_module.
     if (peers == NULL) {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                     "[ngx-healthcheck][http status interface] peers == NULL");

--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -13,10 +13,7 @@
 #include <nginx.h>
 #include "ngx_http_upstream_check_module.h"
 
-
-typedef struct ngx_http_upstream_check_peer_s ngx_http_upstream_check_peer_t;
-typedef struct ngx_http_upstream_check_srv_conf_s
-    ngx_http_upstream_check_srv_conf_t;
+#include "common.h.in"
 
 
 #pragma pack(push, 1)
@@ -73,88 +70,12 @@ typedef struct {
 } ngx_http_upstream_check_ctx_t;
 
 
-typedef struct {
-    ngx_shmtx_t                              mutex;
-#if (nginx_version >= 1002000)
-    ngx_shmtx_sh_t                           lock;
-#else
-    ngx_atomic_t                             lock;
-#endif
-
-    ngx_pid_t                                owner;
-
-    ngx_msec_t                               access_time;
-
-    ngx_uint_t                               fall_count;
-    ngx_uint_t                               rise_count;
-
-    ngx_uint_t                               busyness;
-    ngx_uint_t                               access_count;
-
-    struct sockaddr                         *sockaddr;
-    socklen_t                                socklen;
-
-    ngx_atomic_t                             down;
-
-    u_char                                   padding[64];
-} ngx_http_upstream_check_peer_shm_t;
-
-
-typedef struct {
-    ngx_uint_t                               generation;
-    ngx_uint_t                               checksum;
-    ngx_uint_t                               number;
-
-    /* ngx_http_upstream_check_status_peer_t */
-    ngx_http_upstream_check_peer_shm_t       peers[1];
-} ngx_http_upstream_check_peers_shm_t;
 
 
 #define NGX_HTTP_CHECK_CONNECT_DONE          0x0001
 #define NGX_HTTP_CHECK_SEND_DONE             0x0002
 #define NGX_HTTP_CHECK_RECV_DONE             0x0004
 #define NGX_HTTP_CHECK_ALL_DONE              0x0008
-
-
-typedef ngx_int_t (*ngx_http_upstream_check_packet_init_pt)
-    (ngx_http_upstream_check_peer_t *peer);
-typedef ngx_int_t (*ngx_http_upstream_check_packet_parse_pt)
-    (ngx_http_upstream_check_peer_t *peer);
-typedef void (*ngx_http_upstream_check_packet_clean_pt)
-    (ngx_http_upstream_check_peer_t *peer);
-
-struct ngx_http_upstream_check_peer_s {
-    ngx_flag_t                               state;
-    ngx_pool_t                              *pool;
-    ngx_uint_t                               index;
-    ngx_uint_t                               max_busy;
-    ngx_str_t                               *upstream_name;
-    ngx_addr_t                              *check_peer_addr;
-    ngx_addr_t                              *peer_addr;
-    ngx_event_t                              check_ev;
-    ngx_event_t                              check_timeout_ev;
-    ngx_peer_connection_t                    pc;
-
-    void                                    *check_data;
-    ngx_event_handler_pt                     send_handler;
-    ngx_event_handler_pt                     recv_handler;
-
-    ngx_http_upstream_check_packet_init_pt   init;
-    ngx_http_upstream_check_packet_parse_pt  parse;
-    ngx_http_upstream_check_packet_clean_pt  reinit;
-
-    ngx_http_upstream_check_peer_shm_t      *shm;
-    ngx_http_upstream_check_srv_conf_t      *conf;
-};
-
-
-typedef struct {
-    ngx_str_t                                check_shm_name;
-    ngx_uint_t                               checksum;
-    ngx_array_t                              peers;
-
-    ngx_http_upstream_check_peers_shm_t     *peers_shm;
-} ngx_http_upstream_check_peers_t;
 
 
 #define NGX_HTTP_CHECK_TCP                   0x0001
@@ -169,30 +90,10 @@ typedef struct {
 #define NGX_CHECK_HTTP_5XX                   0x0010
 #define NGX_CHECK_HTTP_ERR                   0x8000
 
-typedef struct {
-    ngx_uint_t                               type;
-
-    ngx_str_t                                name;
-
-    ngx_str_t                                default_send;
-
-    /* HTTP */
-    ngx_uint_t                               default_status_alive;
-
-    ngx_event_handler_pt                     send_handler;
-    ngx_event_handler_pt                     recv_handler;
-
-    ngx_http_upstream_check_packet_init_pt   init;
-    ngx_http_upstream_check_packet_parse_pt  parse;
-    ngx_http_upstream_check_packet_clean_pt  reinit;
-
-    unsigned need_pool;
-    unsigned need_keepalive;
-} ngx_check_conf_t;
 
 
 typedef void (*ngx_http_upstream_check_status_format_pt) (ngx_buf_t *b,
-    ngx_http_upstream_check_peers_t *peers, ngx_uint_t flag);
+    ngx_stream_upstream_check_peers_t *peers, ngx_uint_t flag);
 
 typedef struct {
     ngx_str_t                                format;
@@ -222,30 +123,8 @@ typedef struct {
 
 typedef struct {
     ngx_uint_t                               check_shm_size;
-    ngx_http_upstream_check_peers_t         *peers;
+    ngx_stream_upstream_check_peers_t         *peers;
 } ngx_http_upstream_check_main_conf_t;
-
-
-struct ngx_http_upstream_check_srv_conf_s {
-    ngx_uint_t                               port;
-    ngx_uint_t                               fall_count;
-    ngx_uint_t                               rise_count;
-    ngx_msec_t                               check_interval;
-    ngx_msec_t                               check_timeout;
-    ngx_uint_t                               check_keepalive_requests;
-
-    ngx_check_conf_t                        *check_type_conf;
-    ngx_str_t                                send;
-
-    union {
-        ngx_uint_t                           return_code;
-        ngx_uint_t                           status_alive;
-    } code;
-
-    ngx_array_t                             *fastcgi_params;
-
-    ngx_uint_t                               default_down;
-};
 
 
 typedef struct {
@@ -355,20 +234,20 @@ static void ngx_http_upstream_check_discard_handler(ngx_event_t *event);
 static void ngx_http_upstream_check_dummy_handler(ngx_event_t *event);
 
 static ngx_int_t ngx_http_upstream_check_http_init(
-    ngx_http_upstream_check_peer_t *peer);
+    ngx_stream_upstream_check_peer_t *peer);
 static ngx_int_t ngx_http_upstream_check_http_parse(
-    ngx_http_upstream_check_peer_t *peer);
+    ngx_stream_upstream_check_peer_t *peer);
 static ngx_int_t ngx_http_upstream_check_parse_status_line(
     ngx_http_upstream_check_ctx_t *ctx, ngx_buf_t *b,
     ngx_http_status_t *status);
 static void ngx_http_upstream_check_http_reinit(
-    ngx_http_upstream_check_peer_t *peer);
+    ngx_stream_upstream_check_peer_t *peer);
 
 static ngx_buf_t *ngx_http_upstream_check_create_fastcgi_request(
     ngx_pool_t *pool, ngx_str_t *params, ngx_uint_t num);
 
 static ngx_int_t ngx_http_upstream_check_fastcgi_parse(
-    ngx_http_upstream_check_peer_t *peer);
+    ngx_stream_upstream_check_peer_t *peer);
 static ngx_int_t ngx_http_upstream_check_fastcgi_process_record(
     ngx_http_upstream_check_ctx_t *ctx, ngx_buf_t *b,
     ngx_http_status_t *status);
@@ -377,32 +256,32 @@ static ngx_int_t ngx_http_upstream_check_parse_fastcgi_status(
     ngx_http_status_t *status);
 
 static ngx_int_t ngx_http_upstream_check_ssl_hello_init(
-    ngx_http_upstream_check_peer_t *peer);
+    ngx_stream_upstream_check_peer_t *peer);
 static ngx_int_t ngx_http_upstream_check_ssl_hello_parse(
-    ngx_http_upstream_check_peer_t *peer);
+    ngx_stream_upstream_check_peer_t *peer);
 static void ngx_http_upstream_check_ssl_hello_reinit(
-    ngx_http_upstream_check_peer_t *peer);
+    ngx_stream_upstream_check_peer_t *peer);
 
 static ngx_int_t ngx_http_upstream_check_mysql_init(
-    ngx_http_upstream_check_peer_t *peer);
+    ngx_stream_upstream_check_peer_t *peer);
 static ngx_int_t ngx_http_upstream_check_mysql_parse(
-    ngx_http_upstream_check_peer_t *peer);
+    ngx_stream_upstream_check_peer_t *peer);
 static void ngx_http_upstream_check_mysql_reinit(
-    ngx_http_upstream_check_peer_t *peer);
+    ngx_stream_upstream_check_peer_t *peer);
 
 static ngx_int_t ngx_http_upstream_check_ajp_init(
-    ngx_http_upstream_check_peer_t *peer);
+    ngx_stream_upstream_check_peer_t *peer);
 static ngx_int_t ngx_http_upstream_check_ajp_parse(
-    ngx_http_upstream_check_peer_t *peer);
+    ngx_stream_upstream_check_peer_t *peer);
 static void ngx_http_upstream_check_ajp_reinit(
-    ngx_http_upstream_check_peer_t *peer);
+    ngx_stream_upstream_check_peer_t *peer);
 
 static void ngx_http_upstream_check_status_update(
-    ngx_http_upstream_check_peer_t *peer,
+    ngx_stream_upstream_check_peer_t *peer,
     ngx_int_t result);
 
 static void ngx_http_upstream_check_clean_event(
-    ngx_http_upstream_check_peer_t *peer);
+    ngx_stream_upstream_check_peer_t *peer);
 
 static void ngx_http_upstream_check_timeout_handler(ngx_event_t *event);
 static void ngx_http_upstream_check_finish_handler(ngx_event_t *event);
@@ -422,11 +301,11 @@ static ngx_int_t ngx_http_upstream_check_status_command_status(
     ngx_http_upstream_check_status_ctx_t *ctx, ngx_str_t *value);
 
 static void ngx_http_upstream_check_status_html_format(ngx_buf_t *b,
-    ngx_http_upstream_check_peers_t *peers, ngx_uint_t flag);
+    ngx_stream_upstream_check_peers_t *peers, ngx_uint_t flag);
 static void ngx_http_upstream_check_status_csv_format(ngx_buf_t *b,
-    ngx_http_upstream_check_peers_t *peers, ngx_uint_t flag);
+    ngx_stream_upstream_check_peers_t *peers, ngx_uint_t flag);
 static void ngx_http_upstream_check_status_json_format(ngx_buf_t *b,
-    ngx_http_upstream_check_peers_t *peers, ngx_uint_t flag);
+    ngx_stream_upstream_check_peers_t *peers, ngx_uint_t flag);
 
 static ngx_int_t ngx_http_upstream_check_addr_change_port(ngx_pool_t *pool,
     ngx_addr_t *dst, ngx_addr_t *src, ngx_uint_t port);
@@ -472,13 +351,13 @@ static ngx_int_t ngx_http_upstream_check_get_shm_name(ngx_str_t *shm_name,
     ngx_pool_t *pool, ngx_uint_t generation);
 static ngx_shm_zone_t *ngx_shared_memory_find(ngx_cycle_t *cycle,
     ngx_str_t *name, void *tag);
-static ngx_http_upstream_check_peer_shm_t *
-ngx_http_upstream_check_find_shm_peer(ngx_http_upstream_check_peers_shm_t *peers_shm,
+static ngx_stream_upstream_check_peer_shm_t *
+ngx_http_upstream_check_find_shm_peer(ngx_stream_upstream_check_peers_shm_t *peers_shm,
     ngx_addr_t *addr);
 
 static ngx_int_t ngx_http_upstream_check_init_shm_peer(
-    ngx_http_upstream_check_peer_shm_t *peer_shm,
-    ngx_http_upstream_check_peer_shm_t *opeer_shm,
+    ngx_stream_upstream_check_peer_shm_t *peer_shm,
+    ngx_stream_upstream_check_peer_shm_t *opeer_shm,
     ngx_uint_t init_down, ngx_pool_t *pool, ngx_str_t *peer_name);
 
 static ngx_int_t ngx_http_upstream_check_init_shm_zone(
@@ -766,16 +645,16 @@ static ngx_check_status_command_t ngx_check_status_commands[] =  {
 
 
 static ngx_uint_t ngx_http_upstream_check_shm_generation = 0;
-ngx_http_upstream_check_peers_t *http_peers_ctx = NULL;
+ngx_stream_upstream_check_peers_t *http_peers_ctx = NULL;
 
 
 ngx_uint_t
 ngx_http_upstream_check_add_peer(ngx_conf_t *cf,
     ngx_http_upstream_srv_conf_t *us, ngx_addr_t *peer_addr)
 {
-    ngx_http_upstream_check_peer_t       *peer;
-    ngx_http_upstream_check_peers_t      *peers;
-    ngx_http_upstream_check_srv_conf_t   *ucscf;
+    ngx_stream_upstream_check_peer_t       *peer;
+    ngx_stream_upstream_check_peers_t      *peers;
+    ngx_stream_upstream_check_srv_conf_t   *ucscf;
     ngx_http_upstream_check_main_conf_t  *ucmcf;
 
     if (us->srv_conf == NULL) {
@@ -797,7 +676,7 @@ ngx_http_upstream_check_add_peer(ngx_conf_t *cf,
         return NGX_ERROR;
     }
 
-    ngx_memzero(peer, sizeof(ngx_http_upstream_check_peer_t));
+    ngx_memzero(peer, sizeof(ngx_stream_upstream_check_peer_t));
 
     peer->index = peers->peers.nelts - 1;
     peer->conf = ucscf;
@@ -892,7 +771,7 @@ ngx_http_upstream_check_addr_change_port(ngx_pool_t *pool, ngx_addr_t *dst,
 ngx_uint_t
 ngx_http_upstream_check_peer_down(ngx_uint_t index)
 {
-    ngx_http_upstream_check_peer_t  *peer;
+    ngx_stream_upstream_check_peer_t  *peer;
 
     if (http_peers_ctx == NULL || index >= http_peers_ctx->peers.nelts) {
         return 0;
@@ -908,7 +787,7 @@ ngx_http_upstream_check_peer_down(ngx_uint_t index)
 void
 ngx_http_upstream_check_get_peer(ngx_uint_t index)
 {
-    ngx_http_upstream_check_peer_t  *peer;
+    ngx_stream_upstream_check_peer_t  *peer;
 
     if (http_peers_ctx == NULL || index >= http_peers_ctx->peers.nelts) {
         return;
@@ -928,7 +807,7 @@ ngx_http_upstream_check_get_peer(ngx_uint_t index)
 void
 ngx_http_upstream_check_free_peer(ngx_uint_t index)
 {
-    ngx_http_upstream_check_peer_t  *peer;
+    ngx_stream_upstream_check_peer_t  *peer;
 
     if (http_peers_ctx == NULL || index >= http_peers_ctx->peers.nelts) {
         return;
@@ -952,11 +831,11 @@ ngx_http_upstream_check_add_timers(ngx_cycle_t *cycle)
     ngx_uint_t                           i;
     ngx_msec_t                           t, delay;
     ngx_check_conf_t                    *cf;
-    ngx_http_upstream_check_peer_t      *peer;
-    ngx_http_upstream_check_peers_t     *peers;
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
-    ngx_http_upstream_check_peer_shm_t  *peer_shm;
-    ngx_http_upstream_check_peers_shm_t *peers_shm;
+    ngx_stream_upstream_check_peer_t      *peer;
+    ngx_stream_upstream_check_peers_t     *peers;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_peer_shm_t  *peer_shm;
+    ngx_stream_upstream_check_peers_shm_t *peers_shm;
 
     peers = http_peers_ctx;
     if (peers == NULL) {
@@ -1028,10 +907,10 @@ static void
 ngx_http_upstream_check_begin_handler(ngx_event_t *event)
 {
     ngx_msec_t                           interval;
-    ngx_http_upstream_check_peer_t      *peer;
-    ngx_http_upstream_check_peers_t     *peers;
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
-    ngx_http_upstream_check_peers_shm_t *peers_shm;
+    ngx_stream_upstream_check_peer_t      *peer;
+    ngx_stream_upstream_check_peers_t     *peers;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_peers_shm_t *peers_shm;
 
     if (ngx_http_upstream_check_need_exit()) {
         return;
@@ -1105,8 +984,8 @@ ngx_http_upstream_check_connect_handler(ngx_event_t *event)
 {
     ngx_int_t                            rc;
     ngx_connection_t                    *c;
-    ngx_http_upstream_check_peer_t      *peer;
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_peer_t      *peer;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
 
     if (ngx_http_upstream_check_need_exit()) {
         return;
@@ -1193,7 +1072,7 @@ static void
 ngx_http_upstream_check_peek_handler(ngx_event_t *event)
 {
     ngx_connection_t               *c;
-    ngx_http_upstream_check_peer_t *peer;
+    ngx_stream_upstream_check_peer_t *peer;
 
     if (ngx_http_upstream_check_need_exit()) {
         return;
@@ -1222,7 +1101,7 @@ ngx_http_upstream_check_discard_handler(ngx_event_t *event)
     u_char                          buf[4096];
     ssize_t                         size;
     ngx_connection_t               *c;
-    ngx_http_upstream_check_peer_t *peer;
+    ngx_stream_upstream_check_peer_t *peer;
 
     c = event->data;
 
@@ -1279,7 +1158,7 @@ ngx_http_upstream_check_send_handler(ngx_event_t *event)
     ssize_t                         size;
     ngx_connection_t               *c;
     ngx_http_upstream_check_ctx_t  *ctx;
-    ngx_http_upstream_check_peer_t *peer;
+    ngx_stream_upstream_check_peer_t *peer;
 
     if (ngx_http_upstream_check_need_exit()) {
         return;
@@ -1378,7 +1257,7 @@ ngx_http_upstream_check_recv_handler(ngx_event_t *event)
     ngx_int_t                       rc;
     ngx_connection_t               *c;
     ngx_http_upstream_check_ctx_t  *ctx;
-    ngx_http_upstream_check_peer_t *peer;
+    ngx_stream_upstream_check_peer_t *peer;
 
     if (ngx_http_upstream_check_need_exit()) {
         return;
@@ -1499,10 +1378,10 @@ check_recv_fail:
 
 
 static ngx_int_t
-ngx_http_upstream_check_http_init(ngx_http_upstream_check_peer_t *peer)
+ngx_http_upstream_check_http_init(ngx_stream_upstream_check_peer_t *peer)
 {
     ngx_http_upstream_check_ctx_t       *ctx;
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
 
     ctx = peer->check_data;
     ucscf = peer->conf;
@@ -1522,12 +1401,12 @@ ngx_http_upstream_check_http_init(ngx_http_upstream_check_peer_t *peer)
 
 
 static ngx_int_t
-ngx_http_upstream_check_http_parse(ngx_http_upstream_check_peer_t *peer)
+ngx_http_upstream_check_http_parse(ngx_stream_upstream_check_peer_t *peer)
 {
     ngx_int_t                            rc;
     ngx_uint_t                           code, code_n;
     ngx_http_upstream_check_ctx_t       *ctx;
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
 
     ucscf = peer->conf;
     ctx = peer->check_data;
@@ -1686,13 +1565,13 @@ ngx_http_upstream_check_fastcgi_process_record(
 
 
 static ngx_int_t
-ngx_http_upstream_check_fastcgi_parse(ngx_http_upstream_check_peer_t *peer)
+ngx_http_upstream_check_fastcgi_parse(ngx_stream_upstream_check_peer_t *peer)
 {
     ngx_int_t                            rc;
     ngx_flag_t                           done;
     ngx_uint_t                           type, code, code_n;
     ngx_http_upstream_check_ctx_t       *ctx;
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
 
     ucscf = peer->conf;
     ctx = peer->check_data;
@@ -2293,7 +2172,7 @@ done:
 
 
 static void
-ngx_http_upstream_check_http_reinit(ngx_http_upstream_check_peer_t *peer)
+ngx_http_upstream_check_http_reinit(ngx_stream_upstream_check_peer_t *peer)
 {
     ngx_http_upstream_check_ctx_t  *ctx;
 
@@ -2311,10 +2190,10 @@ ngx_http_upstream_check_http_reinit(ngx_http_upstream_check_peer_t *peer)
 
 
 static ngx_int_t
-ngx_http_upstream_check_ssl_hello_init(ngx_http_upstream_check_peer_t *peer)
+ngx_http_upstream_check_ssl_hello_init(ngx_stream_upstream_check_peer_t *peer)
 {
     ngx_http_upstream_check_ctx_t       *ctx;
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
 
     ctx = peer->check_data;
     ucscf = peer->conf;
@@ -2331,7 +2210,7 @@ ngx_http_upstream_check_ssl_hello_init(ngx_http_upstream_check_peer_t *peer)
 
 /* a rough check of server ssl_hello responses */
 static ngx_int_t
-ngx_http_upstream_check_ssl_hello_parse(ngx_http_upstream_check_peer_t *peer)
+ngx_http_upstream_check_ssl_hello_parse(ngx_stream_upstream_check_peer_t *peer)
 {
     size_t                         size;
     ngx_ssl_server_hello_t        *resp;
@@ -2366,7 +2245,7 @@ ngx_http_upstream_check_ssl_hello_parse(ngx_http_upstream_check_peer_t *peer)
 
 
 static void
-ngx_http_upstream_check_ssl_hello_reinit(ngx_http_upstream_check_peer_t *peer)
+ngx_http_upstream_check_ssl_hello_reinit(ngx_stream_upstream_check_peer_t *peer)
 {
     ngx_http_upstream_check_ctx_t *ctx;
 
@@ -2380,10 +2259,10 @@ ngx_http_upstream_check_ssl_hello_reinit(ngx_http_upstream_check_peer_t *peer)
 
 
 static ngx_int_t
-ngx_http_upstream_check_mysql_init(ngx_http_upstream_check_peer_t *peer)
+ngx_http_upstream_check_mysql_init(ngx_stream_upstream_check_peer_t *peer)
 {
     ngx_http_upstream_check_ctx_t       *ctx;
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
 
     ctx = peer->check_data;
     ucscf = peer->conf;
@@ -2400,7 +2279,7 @@ ngx_http_upstream_check_mysql_init(ngx_http_upstream_check_peer_t *peer)
 
 /* a rough check of mysql greeting responses */
 static ngx_int_t
-ngx_http_upstream_check_mysql_parse(ngx_http_upstream_check_peer_t *peer)
+ngx_http_upstream_check_mysql_parse(ngx_stream_upstream_check_peer_t *peer)
 {
     size_t                         size;
     ngx_mysql_handshake_init_t    *handshake;
@@ -2430,7 +2309,7 @@ ngx_http_upstream_check_mysql_parse(ngx_http_upstream_check_peer_t *peer)
 
 
 static void
-ngx_http_upstream_check_mysql_reinit(ngx_http_upstream_check_peer_t *peer)
+ngx_http_upstream_check_mysql_reinit(ngx_stream_upstream_check_peer_t *peer)
 {
     ngx_http_upstream_check_ctx_t *ctx;
 
@@ -2444,10 +2323,10 @@ ngx_http_upstream_check_mysql_reinit(ngx_http_upstream_check_peer_t *peer)
 
 
 static ngx_int_t
-ngx_http_upstream_check_ajp_init(ngx_http_upstream_check_peer_t *peer)
+ngx_http_upstream_check_ajp_init(ngx_stream_upstream_check_peer_t *peer)
 {
     ngx_http_upstream_check_ctx_t       *ctx;
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
 
     ctx = peer->check_data;
     ucscf = peer->conf;
@@ -2463,7 +2342,7 @@ ngx_http_upstream_check_ajp_init(ngx_http_upstream_check_peer_t *peer)
 
 
 static ngx_int_t
-ngx_http_upstream_check_ajp_parse(ngx_http_upstream_check_peer_t *peer)
+ngx_http_upstream_check_ajp_parse(ngx_stream_upstream_check_peer_t *peer)
 {
     size_t                         size;
     u_char                        *p;
@@ -2499,7 +2378,7 @@ ngx_http_upstream_check_ajp_parse(ngx_http_upstream_check_peer_t *peer)
 
 
 static void
-ngx_http_upstream_check_ajp_reinit(ngx_http_upstream_check_peer_t *peer)
+ngx_http_upstream_check_ajp_reinit(ngx_stream_upstream_check_peer_t *peer)
 {
     ngx_http_upstream_check_ctx_t  *ctx;
 
@@ -2513,10 +2392,10 @@ ngx_http_upstream_check_ajp_reinit(ngx_http_upstream_check_peer_t *peer)
 
 
 static void
-ngx_http_upstream_check_status_update(ngx_http_upstream_check_peer_t *peer,
+ngx_http_upstream_check_status_update(ngx_stream_upstream_check_peer_t *peer,
     ngx_int_t result)
 {
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
 
     ucscf = peer->conf;
 
@@ -2545,10 +2424,10 @@ ngx_http_upstream_check_status_update(ngx_http_upstream_check_peer_t *peer,
 
 
 static void
-ngx_http_upstream_check_clean_event(ngx_http_upstream_check_peer_t *peer)
+ngx_http_upstream_check_clean_event(ngx_stream_upstream_check_peer_t *peer)
 {
     ngx_connection_t                    *c;
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
     ngx_check_conf_t                    *cf;
 
     c = peer->pc.connection;
@@ -2588,7 +2467,7 @@ ngx_http_upstream_check_clean_event(ngx_http_upstream_check_peer_t *peer)
 static void
 ngx_http_upstream_check_timeout_handler(ngx_event_t *event)
 {
-    ngx_http_upstream_check_peer_t  *peer;
+    ngx_stream_upstream_check_peer_t  *peer;
 
     if (ngx_http_upstream_check_need_exit()) {
         return;
@@ -2632,8 +2511,8 @@ ngx_http_upstream_check_clear_all_events()
 {
     ngx_uint_t                       i;
     ngx_connection_t                *c;
-    ngx_http_upstream_check_peer_t  *peer;
-    ngx_http_upstream_check_peers_t *peers;
+    ngx_stream_upstream_check_peer_t  *peer;
+    ngx_stream_upstream_check_peers_t *peers;
 
     static ngx_flag_t                has_cleared = 0;
 
@@ -2680,7 +2559,7 @@ ngx_http_upstream_check_status_handler(ngx_http_request_t *r)
     ngx_int_t                              rc;
     ngx_buf_t                             *b;
     ngx_chain_t                            out;
-    ngx_http_upstream_check_peers_t       *peers;
+    ngx_stream_upstream_check_peers_t       *peers;
     ngx_http_upstream_check_loc_conf_t    *uclcf;
     ngx_http_upstream_check_status_ctx_t  *ctx;
 
@@ -2835,10 +2714,10 @@ ngx_http_upstream_check_status_command_status(
 
 static void
 ngx_http_upstream_check_status_html_format(ngx_buf_t *b,
-    ngx_http_upstream_check_peers_t *peers, ngx_uint_t flag)
+    ngx_stream_upstream_check_peers_t *peers, ngx_uint_t flag)
 {
     ngx_uint_t                      i, count;
-    ngx_http_upstream_check_peer_t *peer;
+    ngx_stream_upstream_check_peer_t *peer;
 
     peer = peers->peers.elts;
 
@@ -2932,10 +2811,10 @@ ngx_http_upstream_check_status_html_format(ngx_buf_t *b,
 
 static void
 ngx_http_upstream_check_status_csv_format(ngx_buf_t *b,
-    ngx_http_upstream_check_peers_t *peers, ngx_uint_t flag)
+    ngx_stream_upstream_check_peers_t *peers, ngx_uint_t flag)
 {
     ngx_uint_t                       i;
-    ngx_http_upstream_check_peer_t  *peer;
+    ngx_stream_upstream_check_peer_t  *peer;
 
     peer = peers->peers.elts;
     for (i = 0; i < peers->peers.nelts; i++) {
@@ -2969,10 +2848,10 @@ ngx_http_upstream_check_status_csv_format(ngx_buf_t *b,
 
 static void
 ngx_http_upstream_check_status_json_format(ngx_buf_t *b,
-    ngx_http_upstream_check_peers_t *peers, ngx_uint_t flag)
+    ngx_stream_upstream_check_peers_t *peers, ngx_uint_t flag)
 {
     ngx_uint_t                       count, i, last;
-    ngx_http_upstream_check_peer_t  *peer;
+    ngx_stream_upstream_check_peer_t  *peer;
 
     peer = peers->peers.elts;
 
@@ -3081,7 +2960,7 @@ ngx_http_upstream_check(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_str_t                           *value, s;
     ngx_uint_t                           i, port, rise, fall, default_down;
     ngx_msec_t                           interval, timeout;
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
 
     /* default values */
     port = 0;
@@ -3224,7 +3103,7 @@ ngx_http_upstream_check_keepalive_requests(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf)
 {
     ngx_str_t                           *value;
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
     ngx_uint_t                           requests;
 
     value = cf->args->elts;
@@ -3248,7 +3127,7 @@ ngx_http_upstream_check_http_send(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf)
 {
     ngx_str_t                           *value;
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
 
     value = cf->args->elts;
 
@@ -3266,7 +3145,7 @@ ngx_http_upstream_check_fastcgi_params(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf)
 {
     ngx_str_t                           *value, *k, *v;
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
 
     value = cf->args->elts;
 
@@ -3297,7 +3176,7 @@ ngx_http_upstream_check_http_expect_alive(ngx_conf_t *cf, ngx_command_t *cmd,
     ngx_str_t                           *value;
     ngx_uint_t                           bit, i, m;
     ngx_conf_bitmask_t                  *mask;
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
 
     value = cf->args->elts;
     mask = ngx_check_http_expect_alive_masks;
@@ -3430,7 +3309,7 @@ ngx_http_upstream_check_create_main_conf(ngx_conf_t *cf)
     }
 
     ucmcf->peers = ngx_pcalloc(cf->pool,
-                               sizeof(ngx_http_upstream_check_peers_t));
+                               sizeof(ngx_stream_upstream_check_peers_t));
     if (ucmcf->peers == NULL) {
         return NULL;
     }
@@ -3438,7 +3317,7 @@ ngx_http_upstream_check_create_main_conf(ngx_conf_t *cf)
     ucmcf->peers->checksum = 0;
 
     if (ngx_array_init(&ucmcf->peers->peers, cf->pool, 16,
-                       sizeof(ngx_http_upstream_check_peer_t)) != NGX_OK)
+                       sizeof(ngx_stream_upstream_check_peer_t)) != NGX_OK)
     {
         return NULL;
     }
@@ -3590,9 +3469,9 @@ ngx_http_upstream_check_init_main_conf(ngx_conf_t *cf, void *conf)
 static void *
 ngx_http_upstream_check_create_srv_conf(ngx_conf_t *cf)
 {
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
 
-    ucscf = ngx_pcalloc(cf->pool, sizeof(ngx_http_upstream_check_srv_conf_t));
+    ucscf = ngx_pcalloc(cf->pool, sizeof(ngx_stream_upstream_check_srv_conf_t));
     if (ucscf == NULL) {
         return NULL;
     }
@@ -3636,7 +3515,7 @@ ngx_http_upstream_check_init_srv_conf(ngx_conf_t *cf, void *conf)
     ngx_buf_t                          *b;
     ngx_check_conf_t                   *check;
     ngx_http_upstream_srv_conf_t       *us = conf;
-    ngx_http_upstream_check_srv_conf_t *ucscf;
+    ngx_stream_upstream_check_srv_conf_t *ucscf;
 
     if (us->srv_conf == NULL) {
         return NGX_CONF_OK;
@@ -3800,11 +3679,11 @@ ngx_http_upstream_check_init_shm_zone(ngx_shm_zone_t *shm_zone, void *data)
     ngx_pool_t                          *pool;
     ngx_shm_zone_t                      *oshm_zone;
     ngx_slab_pool_t                     *shpool;
-    ngx_http_upstream_check_peer_t      *peer;
-    ngx_http_upstream_check_peers_t     *peers;
-    ngx_http_upstream_check_srv_conf_t  *ucscf;
-    ngx_http_upstream_check_peer_shm_t  *peer_shm, *opeer_shm;
-    ngx_http_upstream_check_peers_shm_t *peers_shm, *opeers_shm;
+    ngx_stream_upstream_check_peer_t      *peer;
+    ngx_stream_upstream_check_peers_t     *peers;
+    ngx_stream_upstream_check_srv_conf_t  *ucscf;
+    ngx_stream_upstream_check_peer_shm_t  *peer_shm, *opeer_shm;
+    ngx_stream_upstream_check_peers_shm_t *peers_shm, *opeers_shm;
 
     opeers_shm = NULL;
     peers_shm = NULL;
@@ -3828,6 +3707,9 @@ ngx_http_upstream_check_init_shm_zone(ngx_shm_zone_t *shm_zone, void *data)
 
     shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
 
+    ngx_log_error(NGX_LOG_INFO, shm_zone->shm.log, 0,
+                  "[ngx-healthcheck][http] old data: %p ",data);
+                  
     if (data) {
         opeers_shm = data;
 
@@ -3862,7 +3744,7 @@ ngx_http_upstream_check_init_shm_zone(ngx_shm_zone_t *shm_zone, void *data)
         }
 
         size = sizeof(*peers_shm) +
-               (number - 1) * sizeof(ngx_http_upstream_check_peer_shm_t);
+               (number - 1) * sizeof(ngx_stream_upstream_check_peer_shm_t);
 
         peers_shm = ngx_slab_alloc(shpool, size);
 
@@ -3904,7 +3786,7 @@ ngx_http_upstream_check_init_shm_zone(ngx_shm_zone_t *shm_zone, void *data)
                    peer_shm->socklen);
 
         if (opeers_shm) {
-
+//todo:bug
             opeer_shm = ngx_http_upstream_check_find_shm_peer(opeers_shm,
                                                               peer[i].peer_addr);
             if (opeer_shm) {
@@ -3985,12 +3867,12 @@ ngx_shared_memory_find(ngx_cycle_t *cycle, ngx_str_t *name, void *tag)
 }
 
 
-static ngx_http_upstream_check_peer_shm_t *
-ngx_http_upstream_check_find_shm_peer(ngx_http_upstream_check_peers_shm_t *p,
+static ngx_stream_upstream_check_peer_shm_t *
+ngx_http_upstream_check_find_shm_peer(ngx_stream_upstream_check_peers_shm_t *p,
     ngx_addr_t *addr)
 {
     ngx_uint_t                          i;
-    ngx_http_upstream_check_peer_shm_t *peer_shm;
+    ngx_stream_upstream_check_peer_shm_t *peer_shm;
 
     for (i = 0; i < p->number; i++) {
 
@@ -3999,7 +3881,7 @@ ngx_http_upstream_check_find_shm_peer(ngx_http_upstream_check_peers_shm_t *p,
         if (addr->socklen != peer_shm->socklen) {
             continue;
         }
-
+//zcx:todo: segv
         if (ngx_memcmp(addr->sockaddr, peer_shm->sockaddr, addr->socklen) == 0) {
             return peer_shm;
         }
@@ -4010,8 +3892,8 @@ ngx_http_upstream_check_find_shm_peer(ngx_http_upstream_check_peers_shm_t *p,
 
 
 static ngx_int_t
-ngx_http_upstream_check_init_shm_peer(ngx_http_upstream_check_peer_shm_t *psh,
-    ngx_http_upstream_check_peer_shm_t *opsh, ngx_uint_t init_down,
+ngx_http_upstream_check_init_shm_peer(ngx_stream_upstream_check_peer_shm_t *psh,
+    ngx_stream_upstream_check_peer_shm_t *opsh, ngx_uint_t init_down,
     ngx_pool_t *pool, ngx_str_t *name)
 {
     u_char  *file;

--- a/ngx_stream_upstream_check_module.c
+++ b/ngx_stream_upstream_check_module.c
@@ -7,6 +7,7 @@
 #include <ngx_core.h>
 #include <ngx_stream.h>
 #include <ngx_http.h>
+
 #include "ngx_stream_upstream_check_module.h"
 
 typedef struct ngx_stream_upstream_check_peer_s ngx_stream_upstream_check_peer_t;
@@ -59,8 +60,10 @@ typedef struct {
     ngx_uint_t                               number;
 
     /* ngx_stream_upstream_check_status_peer_t */
-    ngx_stream_upstream_check_peer_shm_t       peers[1];
-} ngx_stream_upstream_check_peers_shm_t;
+    ngx_stream_upstream_check_peer_shm_t       peers[1]; //hack: peer[0]
+} ngx_stream_upstream_check_peers_shm_t; 
+                                         /* followed with (peers_num-1)*ngx_stream_upstream_check_peer_shm_t dynamicly,*/      
+                                         /* so we can ref by peers_shm->peers[0],[1],... */
 
 
 #define NGX_HTTP_CHECK_CONNECT_DONE          0x0001
@@ -382,7 +385,7 @@ static ngx_check_conf_t  ngx_check_types[] = {
                 NULL,
                 NULL,
                 NULL,
-                0,   //zhoucx: need_pool ?
+                0,   //zhoucx: need_pool ? no, we just connect peer.
                 0 }, //zhoucx: need_keepalive ? i change it to no
         { NGX_HTTP_CHECK_UDP,
                 ngx_string("udp"),
@@ -394,7 +397,7 @@ static ngx_check_conf_t  ngx_check_types[] = {
                 ngx_stream_upstream_check_http_init,
                 NULL,
                 ngx_stream_upstream_check_http_reinit,
-                1,
+                1,    // (changxun): when send data, we need pool
                 0 },
         { NGX_HTTP_CHECK_HTTP,
                 ngx_string("http"),
@@ -424,7 +427,7 @@ static ngx_check_conf_t  ngx_check_types[] = {
 //static ngx_uint_t ngx_stream_upstream_check_shm_generation = 0; //zhoucx: what's mean?
 //static ngx_stream_upstream_check_peers_t *check_peers_ctx = NULL;
  ngx_uint_t ngx_stream_upstream_check_shm_generation = 0; //reload counter
- ngx_stream_upstream_check_peers_t *check_peers_ctx = NULL;
+ ngx_stream_upstream_check_peers_t *check_peers_ctx = NULL; //need by check status module
 
 
 ngx_uint_t
@@ -436,8 +439,8 @@ ngx_stream_upstream_check_add_peer(ngx_conf_t *cf,
     ngx_stream_upstream_check_srv_conf_t   *ucscf;
     ngx_stream_upstream_check_main_conf_t  *ucmcf;
 
-    ngx_log_error(NGX_LOG_INFO, cf->log, 0,
-                      "add a peer:( %V ) to stream health check list.",
+    ngx_log_error(NGX_LOG_NOTICE, cf->log, 0,
+                      "[ngx-healthcheck][stream][called by stream module] add a peer:( %V ) to health check list.",
                       &peer_addr->name);
 
     if (us->srv_conf == NULL) {
@@ -622,18 +625,22 @@ ngx_stream_upstream_check_add_timers(ngx_cycle_t *cycle)
 
     peers = check_peers_ctx;
     if (peers == NULL) {
+        ngx_log_error(NGX_LOG_INFO, cycle->log, 0,
+                     "[ngx-healthcheck][init_process][bug]peers==NULL");
         return NGX_OK;
     }
 
     peers_shm = peers->peers_shm;
     if (peers_shm == NULL) {
+        ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0,
+                     "[ngx-healthcheck][stream][timers][when init process]"
+                     "no peers, so skip add timers");
         return NGX_OK;
     }
 
-    ngx_log_debug2(NGX_LOG_DEBUG_STREAM, cycle->log, 0,
-                   "stream check upstream init_process, shm_name: %V, "
-                           "peer number: %ud",
-                   &peers->check_shm_name,
+    ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0,
+                   "[ngx-healthcheck][stream][timers][when init process]"
+                   "start check-timer for %ud peers",
                    peers->peers.nelts);
 
     srandom(ngx_pid);
@@ -644,7 +651,8 @@ ngx_stream_upstream_check_add_timers(ngx_cycle_t *cycle)
     for (i = 0; i < peers->peers.nelts; i++) {
         peer[i].shm = &peer_shm[i];
 
-        peer[i].check_ev.handler = ngx_stream_upstream_check_begin_handler;
+        peer[i].check_ev.handler = 
+                ngx_stream_upstream_check_begin_handler;
         peer[i].check_ev.log = cycle->log;
         peer[i].check_ev.data = &peer[i];
         peer[i].check_ev.timer_set = 0;
@@ -676,8 +684,9 @@ ngx_stream_upstream_check_add_timers(ngx_cycle_t *cycle)
          * We add a random start time here, since we don't want to trigger
          * the check events too close to each other at the beginning.
          */
+        // ensure interval >= 1000ms.
         delay = ucscf->check_interval > 1000 ? ucscf->check_interval : 1000;
-        t = ngx_random() % delay;
+        t = ngx_random() % delay; // t in range(0~999 ms)
 
         ngx_add_timer(&peer[i].check_ev, t);
     }
@@ -695,9 +704,6 @@ ngx_stream_upstream_check_begin_handler(ngx_event_t *event)
     ngx_stream_upstream_check_srv_conf_t  *ucscf;
     ngx_stream_upstream_check_peers_shm_t *peers_shm;
 
-    if (ngx_stream_upstream_check_need_exit()) {
-        return;
-    }
 
     peers = check_peers_ctx;
     if (peers == NULL) {
@@ -711,6 +717,14 @@ ngx_stream_upstream_check_begin_handler(ngx_event_t *event)
 
     peer = event->data;
     ucscf = peer->conf;
+
+    if (ngx_stream_upstream_check_need_exit()) {
+        ngx_log_error(NGX_LOG_NOTICE, event->log, 0,
+                   "[ngx-healthcheck][stream][check-handler][when begin check]"
+                   "recv exit signal, skip current check for peer:(%V)", 
+                   &peer->check_peer_addr->name);
+        return;
+    }
 
     ngx_add_timer(event, ucscf->check_interval / 2);//zhoucx: what's mean?
 
@@ -757,6 +771,10 @@ ngx_stream_upstream_check_begin_handler(ngx_event_t *event)
     ngx_shmtx_unlock(&peer->shm->mutex);
 
     if (peer->shm->owner == ngx_pid) {
+        ngx_log_error(NGX_LOG_INFO, event->log, 0,
+                   "[ngx-healthcheck][stream][check-event][when begin check]"
+                   "restart a check for peer:(%V)", 
+                   &peer->check_peer_addr->name);
         ngx_stream_upstream_check_connect_handler(event);
     }
 }
@@ -770,12 +788,16 @@ ngx_stream_upstream_check_connect_handler(ngx_event_t *event)
     ngx_stream_upstream_check_peer_t      *peer;
     ngx_stream_upstream_check_srv_conf_t  *ucscf;
 
-    if (ngx_stream_upstream_check_need_exit()) {
-        return;
-    }
-
     peer = event->data;
     ucscf = peer->conf;
+
+    if (ngx_stream_upstream_check_need_exit()) {
+        ngx_log_error(NGX_LOG_NOTICE, event->log, 0,
+                   "[ngx-healthcheck][stream][check-handler][when connect peer]"
+                   "recv exit signal, skip current check for peer:(%V)", 
+                   &peer->check_peer_addr->name);
+        return;
+    }
 
     if (peer->pc.connection != NULL) {
         c = peer->pc.connection;
@@ -800,10 +822,10 @@ ngx_stream_upstream_check_connect_handler(ngx_event_t *event)
     peer->pc.cached = 0;
     peer->pc.connection = NULL;
 
-    rc = ngx_event_connect_peer(&peer->pc);
+    rc = ngx_event_connect_peer(&peer->pc); // (changxun): noblocking .
 
     if (rc == NGX_ERROR || rc == NGX_DECLINED) {
-        ngx_stream_upstream_check_status_update(peer, 0);
+        ngx_stream_upstream_check_status_update(peer, 0); //set down
         return;
     }
 
@@ -816,7 +838,7 @@ ngx_stream_upstream_check_connect_handler(ngx_event_t *event)
     c->write->log = c->log;
     c->pool = peer->pool;
 
-	//zhoucx: set sock opt "IP_RECVERR" in order to recv icmp error like host unreachable.
+    /* (changxun): set sock opt "IP_RECVERR" in order to recv icmp error like host/port unreachable. */
     int val = 1;
     if( setsockopt( c->fd, SOL_IP, IP_RECVERR, &val, sizeof(val) ) == -1 ){
         ngx_log_error(NGX_LOG_ERR, event->log, 0,
@@ -848,8 +870,9 @@ ngx_stream_upstream_check_peek_one_byte(ngx_connection_t *c)
     n = recv(c->fd, buf, 1, MSG_PEEK);
     err = ngx_socket_errno;
 
-    ngx_log_debug2(NGX_LOG_DEBUG_STREAM, c->log, err,
-                   "stream check upstream recv(): %i, fd: %d",
+    ngx_log_error(NGX_LOG_INFO, c->log, err,
+                   "[ngx-healthcheck][stream] when recv one byte,"
+                   " recv(): %i, fd: %d",
                    n, c->fd);
 
     if (n == 1 || (n == -1 && err == NGX_EAGAIN)) {
@@ -873,11 +896,11 @@ ngx_stream_upstream_check_peek_handler(ngx_event_t *event)
     peer = c->data;
 
     if (ngx_stream_upstream_check_peek_one_byte(c) == NGX_OK) {
-        ngx_stream_upstream_check_status_update(peer, 1);
+        ngx_stream_upstream_check_status_update(peer, 1); //up
 
     } else {
         c->error = 1;
-        ngx_stream_upstream_check_status_update(peer, 0);
+        ngx_stream_upstream_check_status_update(peer, 0); //down
     }
 
     ngx_stream_upstream_check_clean_event(peer);
@@ -958,7 +981,9 @@ ngx_stream_upstream_check_send_handler(ngx_event_t *event)
     c = event->data;
     peer = c->data;
 
-    ngx_log_debug0(NGX_LOG_DEBUG_STREAM, c->log, 0, "stream check send.");
+    ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                     "[ngx-healthcheck][stream][send-handler] for peer:%V",
+                     &peer->check_peer_addr->name);
 
     if (c->pool == NULL) {
         ngx_log_error(NGX_LOG_ERR, event->log, 0,
@@ -978,7 +1003,7 @@ ngx_stream_upstream_check_send_handler(ngx_event_t *event)
             goto check_send_fail;
         }
 
-        return;
+        return; // (changxun): wait future connect event.
     }
 
     if (peer->check_data == NULL) {
@@ -1002,19 +1027,18 @@ ngx_stream_upstream_check_send_handler(ngx_event_t *event)
     ctx = peer->check_data;
 
     while (ctx->send.pos < ctx->send.last) {
-
+        /* send check data */
         size = c->send(c, ctx->send.pos, ctx->send.last - ctx->send.pos);
 
-#if (NGX_DEBUG)
         {
         ngx_err_t  err;
 
         err = (size >=0) ? 0 : ngx_socket_errno;
-        ngx_log_error(NGX_LOG_DEBUG, ngx_cycle->log, err,
-                       "stream check send size: %z, total: %z",
-                       size, ctx->send.last - ctx->send.pos);
+        ngx_log_error(NGX_LOG_INFO, ngx_cycle->log, err,
+                       "[ngx-healthcheck][stream][send-handler]" 
+                       "send check data size: %z, total: %z for peer:%V",
+                       size, ctx->send.last - ctx->send.pos, &peer->check_peer_addr->name);
         }
-#endif
 
         if (size > 0) {
             ctx->send.pos += size;
@@ -1027,12 +1051,14 @@ ngx_stream_upstream_check_send_handler(ngx_event_t *event)
     }
 
     if (ctx->send.pos == ctx->send.last) {
-        ngx_log_debug0(NGX_LOG_DEBUG_STREAM, c->log, 0, "stream check send done.");
+        ngx_log_error(NGX_LOG_INFO, c->log, 0,
+                     "[ngx-healthcheck][stream][send-handler] send finish for peer:%V",
+                     &peer->check_peer_addr->name);
         peer->state = NGX_HTTP_CHECK_SEND_DONE;
         c->requests++;
     }
 
-    return;
+    return; // normal return;
 
     check_send_fail:
     ngx_stream_upstream_check_status_update(peer, 0);
@@ -1134,7 +1160,7 @@ ngx_stream_upstream_check_recv_handler(ngx_event_t *event)
         case NGX_AGAIN:
             /* The peer has closed its half side of the connection. */
             if (size == 0) {
-                ngx_stream_upstream_check_status_update(peer, 0);
+                ngx_stream_upstream_check_status_update(peer, 0); //down
                 c->error = 1;
                 break;
             }
@@ -1147,14 +1173,14 @@ ngx_stream_upstream_check_recv_handler(ngx_event_t *event)
                           &peer->conf->check_type_conf->name,
                           &peer->check_peer_addr->name);
 
-            ngx_stream_upstream_check_status_update(peer, 0);
+            ngx_stream_upstream_check_status_update(peer, 0); // (changxun): set down
             break;
 
         case NGX_OK:
             /* fall through */
 
         default:
-            ngx_stream_upstream_check_status_update(peer, 1);
+            ngx_stream_upstream_check_status_update(peer, 1); // (changxun): set up
             break;
     }
 
@@ -1163,7 +1189,7 @@ ngx_stream_upstream_check_recv_handler(ngx_event_t *event)
     return;
 
     check_recv_fail:
-    ngx_stream_upstream_check_status_update(peer, 0);
+    ngx_stream_upstream_check_status_update(peer, 0); //down
     ngx_stream_upstream_check_clean_event(peer);
 }
 
@@ -1471,13 +1497,14 @@ ngx_stream_upstream_check_status_update(ngx_stream_upstream_check_peer_t *peer,
 
     ucscf = peer->conf;
 
-    if (result) {
+    if (result) { //up
         peer->shm->rise_count++;
         peer->shm->fall_count = 0;
         if (peer->shm->down && peer->shm->rise_count >= ucscf->rise_count) {
             peer->shm->down = 0;
-            ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
-                          "enable check peer: %V ",
+            ngx_log_error(NGX_LOG_INFO, ngx_cycle->log, 0,
+                          "[ngx-healthcheck][stream][status-update]"
+                          " change status to UP for peer: %V ",
                           &peer->check_peer_addr->name);
         }
     } else {
@@ -1485,8 +1512,9 @@ ngx_stream_upstream_check_status_update(ngx_stream_upstream_check_peer_t *peer,
         peer->shm->fall_count++;
         if (!peer->shm->down && peer->shm->fall_count >= ucscf->fall_count) {
             peer->shm->down = 1;
-            ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
-                          "disable check peer: %V ",
+            ngx_log_error(NGX_LOG_INFO, ngx_cycle->log, 0,
+                          "[ngx-healthcheck][stream][status-update]"
+                          " change status to DOWN for peer: %V ",
                           &peer->check_peer_addr->name);
         }
     }
@@ -1547,23 +1575,26 @@ ngx_stream_upstream_check_timeout_handler(ngx_event_t *event)
 
     peer = event->data;
 
-	if(peer->pc.type == SOCK_STREAM){
-	    peer->pc.connection->error = 1;
-
-	    ngx_log_error(NGX_LOG_ERR, event->log, 0,
-                  "tcp check time out with peer: %V ,set it down.",
-                  &peer->check_peer_addr->name);
-
+    if(peer->pc.type == SOCK_STREAM){
+        peer->pc.connection->error = 1;
+    
+        ngx_log_error(NGX_LOG_ERR, event->log, 0,
+              "[ngx-healthcheck][stream][timers][timeout]"
+              "tcp check time out with peer: %V ,set it down.",
+              &peer->check_peer_addr->name);
+    
         ngx_stream_upstream_check_status_update(peer, 0);
-	}else if(peer->pc.type == SOCK_DGRAM){
-	    peer->pc.connection->error = 0;
-
-	    ngx_log_error(NGX_LOG_INFO, event->log, 0,
-                  "udp check time out with peer: %V, we assum it's up :) ",
-                  &peer->check_peer_addr->name);
-
+    }else if(peer->pc.type == SOCK_DGRAM){
+        peer->pc.connection->error = 0;
+    
+        ngx_log_error(NGX_LOG_INFO, event->log, 0,
+              "[ngx-healthcheck][stream][timers][timeout]"
+              "udp check time out with peer: %V, we assum it's up :) ",
+              &peer->check_peer_addr->name);
+    
         ngx_stream_upstream_check_status_update(peer, 1);
-	}
+    }
+
     ngx_stream_upstream_check_clean_event(peer);
 }
 
@@ -1597,7 +1628,7 @@ ngx_stream_upstream_check_clear_all_events()
     ngx_stream_upstream_check_peer_t  *peer;
     ngx_stream_upstream_check_peers_t *peers;
 
-    static ngx_flag_t                has_cleared = 0; //zhoucx: note! this static var.
+    static ngx_flag_t                has_cleared = 0; // note: this static var.
 
     if (has_cleared || check_peers_ctx == NULL) {
         return;
@@ -1927,6 +1958,7 @@ ngx_stream_upstream_check_create_main_conf(ngx_conf_t *cf)
 {
     ngx_stream_upstream_check_main_conf_t  *ucmcf;
 
+
     ucmcf = ngx_pcalloc(cf->pool, sizeof(ngx_stream_upstream_check_main_conf_t));
     if (ucmcf == NULL) {
         return NULL;
@@ -1961,8 +1993,8 @@ ngx_stream_upstream_check_init_main_conf(ngx_conf_t *cf, void *conf)
 
     uscfp = umcf->upstreams.elts;
 
-    ngx_log_error(NGX_LOG_INFO, cf->log, 0,
-                       "init  stream check main conf. stream upstream check, upstreams size:%ui", 
+    ngx_log_error(NGX_LOG_NOTICE, cf->log, 0,
+                       "[ngx-healthcheck][stream] when init main conf. upstreams num:%ui", 
                        umcf->upstreams.nelts);
     for (i = 0; i < umcf->upstreams.nelts; i++) {
 
@@ -2060,8 +2092,8 @@ ngx_stream_upstream_check_init_shm(ngx_conf_t *cf, void *conf)
     ngx_shm_zone_t                       *shm_zone;
     ngx_stream_upstream_check_main_conf_t  *ucmcf = conf;
 
-    ngx_log_debug1(NGX_LOG_DEBUG_STREAM, cf->log, 0,
-                       "stream upstream check, peers size:%ui", 
+    ngx_log_error(NGX_LOG_INFO, cf->log, 0,
+                       "[ngx-healthcheck][stream][init conf] init shm, total peers num:%ui", 
                        ucmcf->peers->peers.nelts); 
     if (1||(ucmcf->peers->peers.nelts > 0)) {
 
@@ -2081,12 +2113,9 @@ ngx_stream_upstream_check_init_shm(ngx_conf_t *cf, void *conf)
         shm_zone = ngx_shared_memory_add(cf, shm_name, shm_size,
                                          &ngx_stream_upstream_check_module);
 
-        ngx_log_debug2(NGX_LOG_DEBUG_STREAM, cf->log, 0,
-                       "stream upstream check, upsteam:%V, shm_zone size:%ui",
-                       shm_name, shm_size);
 
         shm_zone->data = cf->pool;
-        check_peers_ctx = ucmcf->peers;//zhoucx: init check_peers_ctx obj.
+        check_peers_ctx = ucmcf->peers; //init global var: check_peers_ctx obj.
 
         shm_zone->init = ngx_stream_upstream_check_init_shm_zone;
     }
@@ -2139,6 +2168,11 @@ ngx_stream_upstream_check_init_shm_zone(ngx_shm_zone_t *shm_zone, void *data)
     ngx_str_null(&oshm_name);
 
     same = 0;
+
+
+    ngx_log_error(NGX_LOG_INFO, shm_zone->shm.log, 0,
+                  "[ngx-healthcheck][stream][shm_zone] init callback");
+
     peers = check_peers_ctx;
     if (peers == NULL) {
         return NGX_OK;
@@ -2146,6 +2180,8 @@ ngx_stream_upstream_check_init_shm_zone(ngx_shm_zone_t *shm_zone, void *data)
 
     number = peers->peers.nelts;
     if (number == 0) {
+        ngx_log_error(NGX_LOG_NOTICE, shm_zone->shm.log, 0,
+                  "[ngx-healthcheck][stream][shm_zone] no peers, so skip alloc peer_shm");
         return NGX_OK;
     }
 
@@ -2157,6 +2193,8 @@ ngx_stream_upstream_check_init_shm_zone(ngx_shm_zone_t *shm_zone, void *data)
     shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
 
     if (data) {
+        ngx_log_error(NGX_LOG_INFO, shm_zone->shm.log, 0,
+                  "[ngx-healthcheck][stream][shm_zone] found old shm");
         opeers_shm = data;
 
         if ((opeers_shm->number == number)
@@ -2167,7 +2205,9 @@ ngx_stream_upstream_check_init_shm_zone(ngx_shm_zone_t *shm_zone, void *data)
         }
     }
 
-    if (!same) { //zhoucx: upstream config has changed.
+    if (!same) { 
+        ngx_log_error(NGX_LOG_INFO, shm_zone->shm.log, 0,
+                  "[ngx-healthcheck][stream][shm_zone] upstream data have changed.");
 
         if (ngx_stream_upstream_check_shm_generation > 1) {
 
@@ -2182,16 +2222,16 @@ ngx_stream_upstream_check_init_shm_zone(ngx_shm_zone_t *shm_zone, void *data)
             if (oshm_zone) {
                 opeers_shm = oshm_zone->data;
 
-                ngx_log_debug2(NGX_LOG_DEBUG_STREAM, shm_zone->shm.log, 0,
+                ngx_log_error(NGX_LOG_INFO, shm_zone->shm.log, 0,
                                "stream upstream check, find oshm_zone:%p, "
                                        "opeers_shm: %p",
                                oshm_zone, opeers_shm);
             }
         }
 
+        // alloc peers_shm
         size = sizeof(*peers_shm) +
                (number - 1) * sizeof(ngx_stream_upstream_check_peer_shm_t);
-
         peers_shm = ngx_slab_alloc(shpool, size);
 
         if (peers_shm == NULL) {

--- a/ngx_stream_upstream_check_module.c
+++ b/ngx_stream_upstream_check_module.c
@@ -10,10 +10,7 @@
 #include <ngx_http.h>
 
 #include "ngx_stream_upstream_check_module.h"
-
-typedef struct ngx_stream_upstream_check_peer_s ngx_stream_upstream_check_peer_t;
-typedef struct ngx_stream_upstream_check_srv_conf_s
-        ngx_stream_upstream_check_srv_conf_t;
+#include "common.h.in"
 
 
 typedef struct {
@@ -28,90 +25,11 @@ typedef struct {
 } ngx_stream_upstream_check_ctx_t;
 
 
-typedef struct {
-    ngx_shmtx_t                              mutex;
-#if (nginx_version >= 1002000)
-    ngx_shmtx_sh_t                           lock;
-#else
-    ngx_atomic_t                             lock;
-#endif
-
-    ngx_pid_t                                owner;
-
-    ngx_msec_t                               access_time;
-
-    ngx_uint_t                               fall_count;
-    ngx_uint_t                               rise_count;
-
-    ngx_uint_t                               busyness;
-    ngx_uint_t                               access_count;
-
-    struct sockaddr                         *sockaddr;
-    socklen_t                                socklen;
-
-    ngx_atomic_t                             down;
-    ngx_str_t                               *upstream_name;
-    u_char                                   padding[64];
-} ngx_stream_upstream_check_peer_shm_t;
-
-
-typedef struct {
-    ngx_uint_t                               generation;
-    ngx_uint_t                               checksum;//zhoucx: we can know if peer config file changed by calculate it.
-    ngx_uint_t                               number;
-
-    /* ngx_stream_upstream_check_status_peer_t */
-    ngx_stream_upstream_check_peer_shm_t       peers[1]; //hack: peer[0]
-} ngx_stream_upstream_check_peers_shm_t; 
-                                         /* followed with (peers_num-1)*ngx_stream_upstream_check_peer_shm_t dynamicly,*/      
-                                         /* so we can ref by peers_shm->peers[0],[1],... */
-
-
 #define NGX_HTTP_CHECK_CONNECT_DONE          0x0001
 #define NGX_HTTP_CHECK_SEND_DONE             0x0002
 #define NGX_HTTP_CHECK_RECV_DONE             0x0004
 #define NGX_HTTP_CHECK_ALL_DONE              0x0008
 
-
-typedef ngx_int_t (*ngx_stream_upstream_check_packet_init_pt)
-        (ngx_stream_upstream_check_peer_t *peer);
-typedef ngx_int_t (*ngx_stream_upstream_check_packet_parse_pt)
-        (ngx_stream_upstream_check_peer_t *peer);
-typedef void (*ngx_stream_upstream_check_packet_clean_pt)
-        (ngx_stream_upstream_check_peer_t *peer);
-
-struct ngx_stream_upstream_check_peer_s {
-    ngx_flag_t                               state;
-    ngx_pool_t                              *pool;
-    ngx_uint_t                               index;
-    ngx_uint_t                               max_busy;
-    ngx_str_t                               *upstream_name;
-    ngx_addr_t                              *check_peer_addr;
-    ngx_addr_t                              *peer_addr;
-    ngx_event_t                              check_ev;
-    ngx_event_t                              check_timeout_ev;
-    ngx_peer_connection_t                    pc;
-
-    void                                    *check_data;
-    ngx_event_handler_pt                     send_handler;
-    ngx_event_handler_pt                     recv_handler;
-
-    ngx_stream_upstream_check_packet_init_pt   init; //zhoucx: function ptr
-    ngx_stream_upstream_check_packet_parse_pt  parse;
-    ngx_stream_upstream_check_packet_clean_pt  reinit;
-
-    ngx_stream_upstream_check_peer_shm_t      *shm;
-    ngx_stream_upstream_check_srv_conf_t      *conf;
-};
-
-
-typedef struct {
-    ngx_str_t                                check_shm_name;
-    ngx_uint_t                               checksum;
-    ngx_array_t                              peers;
-
-    ngx_stream_upstream_check_peers_shm_t     *peers_shm;
-} ngx_stream_upstream_check_peers_t;
 
 
 #define NGX_CHECK_TYPE_TCP                   0x0001
@@ -124,28 +42,6 @@ typedef struct {
 #define NGX_CHECK_HTTP_4XX                   0x0008
 #define NGX_CHECK_HTTP_5XX                   0x0010
 #define NGX_CHECK_HTTP_ERR                   0x8000
-
-typedef struct {
-    ngx_uint_t                               type;
-
-    ngx_str_t                                name;
-
-    ngx_str_t                                default_send;
-
-    /* HTTP */
-    ngx_uint_t                               default_status_alive;
-
-    ngx_event_handler_pt                     send_handler;
-    ngx_event_handler_pt                     recv_handler;
-
-    ngx_stream_upstream_check_packet_init_pt   init;
-    ngx_stream_upstream_check_packet_parse_pt  parse;
-    ngx_stream_upstream_check_packet_clean_pt  reinit;
-
-    unsigned need_pool;
-    unsigned need_keepalive;
-} ngx_check_conf_t;
-
 
 typedef void (*ngx_stream_upstream_check_status_format_pt) (ngx_buf_t *b,
                                                             ngx_stream_upstream_check_peers_t *peers, ngx_uint_t flag);
@@ -182,24 +78,6 @@ typedef struct {
 } ngx_stream_upstream_check_main_conf_t;
 
 
-struct ngx_stream_upstream_check_srv_conf_s {
-    ngx_uint_t                               port;
-    ngx_uint_t                               fall_count;
-    ngx_uint_t                               rise_count;
-    ngx_msec_t                               check_interval;
-    ngx_msec_t                               check_timeout;
-    ngx_uint_t                               check_keepalive_requests;
-
-    ngx_check_conf_t                        *check_type_conf;
-    ngx_str_t                                send;
-
-    union {
-        ngx_uint_t                           return_code;
-        ngx_uint_t                           status_alive;
-    } code;
-
-    ngx_uint_t                               default_down;
-};
 
 
 typedef struct {


### PR DESCRIPTION
output like this:
```bash
root@changxun-PC:~/nginx-dev/ngx_healthcheck_module# curl localhost/status
{"servers": {
  "total": 6,
  "generation": 3,
  "http": [
    {"index": 0, "upstream": "http-cluster", "name": "127.0.0.1:8080", "status": "up", "rise": 119, "fall": 0, "type": "http", "port": 0},
    {"index": 1, "upstream": "http-cluster", "name": "127.0.0.2:81", "status": "down", "rise": 0, "fall": 120, "type": "http", "port": 0}
  ],
  "stream": [
    {"index": 0, "upstream": "tcp-cluster", "name": "127.0.0.1:22", "status": "up", "rise": 22, "fall": 0, "type": "tcp", "port": 0},
    {"index": 1, "upstream": "tcp-cluster", "name": "192.168.0.2:22", "status": "down", "rise": 0, "fall": 7, "type": "tcp", "port": 0},
    {"index": 2, "upstream": "udp-cluster", "name": "127.0.0.1:53", "status": "down", "rise": 0, "fall": 120, "type": "udp", "port": 0},
    {"index": 3, "upstream": "udp-cluster", "name": "8.8.8.8:53", "status": "up", "rise": 3, "fall": 0, "type": "udp", "port": 0}
  ]
}}
root@changxun-PC:~/nginx-dev/ngx_healthcheck_module# 
```