### PR TITLE
[feature] Support new directive "check_http_expect_body"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Key features:
 - Four-layer supported detection type: `tcp` / `udp` / `http`
 - Seven-layer supported detection Type: `http` / `fastcgi`
 - Provide a unified http status query interface, output format: `html` / `json` / `csv` / `prometheus`
+- Provide a unified http status query interface, output format: `html` / `json` / `csv` / `prometheus`
+- Support judge status according to http response code or body like `check_http_expect_body ~ ".+OK.+";`
 
 Installation
 ============

--- a/common.h.in
+++ b/common.h.in
@@ -3,7 +3,8 @@
 
 #include <nginx.h>
 #include <ngx_core.h>
-
+#include <ngx_http.h>
+#include <ngx_regex.h>
 
 typedef struct ngx_upstream_check_peer_s ngx_upstream_check_peer_t;
 typedef struct ngx_upstream_check_srv_conf_s ngx_upstream_check_srv_conf_t;
@@ -52,6 +53,7 @@ struct ngx_upstream_check_srv_conf_s {
         ngx_uint_t                           return_code;
         ngx_uint_t                           status_alive;
     } code;
+    ngx_regex_t                             *expect_body_regex;
     ngx_array_t                             *fastcgi_params; //only for http module.
     ngx_uint_t                               default_down;
 };

--- a/config
+++ b/config
@@ -6,6 +6,7 @@ ngx_feature_deps="$ngx_addon_dir/ngx_http_upstream_check_module.h \
                   $ngx_addon_dir/ngx_stream_upstream_check_module.h "
 ngx_feature_src="$ngx_addon_dir/ngx_http_upstream_check_module.c \
                  $ngx_addon_dir/ngx_stream_upstream_check_module.c \
+                 $ngx_addon_dir/ngx_healthcheck_common.c \
                  $ngx_addon_dir/ngx_healthcheck_status.c "
 
 

--- a/nginx.conf.example
+++ b/nginx.conf.example
@@ -2,6 +2,7 @@
 worker_processes  1;
 error_log  logs/error.log  info;
 #error_log  logs/debug_stream.log  debug_stream;
+error_log  logs/debug_http.log  debug_http;
 #pid        logs/nginx.pid;
 
 events {
@@ -48,6 +49,8 @@ http {
         check interval=3000 rise=2 fall=5 timeout=5000 type=http;
         check_http_send "GET /heartbeat HTTP/1.0\r\n\r\n";
         check_http_expect_alive http_2xx http_3xx;
+        # I just wanna enable servers whose response content contain ('server1' or 'server3') and 'UP'
+        check_http_expect_body ~ "server[13].+UP";
     }
 }
 
@@ -57,6 +60,7 @@ stream {
         server 127.0.0.1:22; # nomarl
         server 192.168.0.2:22;
         check interval=3000 rise=2 fall=5 timeout=5000 default_down=true type=tcp;
+        #check_http_send "UDP_TEST";
     }
     upstream udp-cluster {
         # simple round-robin
@@ -77,5 +81,7 @@ stream {
         # when use keepalive, you must use HTTP/1.1 with Host like above, or use HTTP/1.0 with header 'Connection: Keep-Alive'
         check_keepalive_requests 10;
         check_http_expect_alive http_2xx http_3xx;
+        # I just wanna enable servers whose response content contain ('server1' or 'server3') and 'UP'
+        check_http_expect_body ~ "server[13].+UP";
     }
 }

--- a/ngx_healthcheck_common.c
+++ b/ngx_healthcheck_common.c
@@ -1,0 +1,272 @@
+/*
+ * Copyright (C) 2017- Changxun Zhou(changxunzhou@qq.com)
+ * desc: nginx upstream server health check.
+ * date: 2020-06-21 23:40
+ */
+#include "common.h.in"
+
+ngx_int_t
+ngx_upstream_check_http_body_regex(ngx_conf_t *cf, ngx_upstream_check_srv_conf_t  *ucscf,
+    ngx_str_t *regex, ngx_uint_t caseless)
+{
+#if (NGX_PCRE)
+    ngx_regex_compile_t  rc;
+    u_char               errstr[NGX_MAX_CONF_ERRSTR];
+
+    ngx_memzero(&rc, sizeof(ngx_regex_compile_t));
+
+    rc.pattern = *regex;
+
+rc.err.len = NGX_MAX_CONF_ERRSTR;
+    rc.err.data = errstr;
+    rc.pool = cf->pool;
+
+#if (NGX_HAVE_CASELESS_FILESYSTEM)
+    rc.options = NGX_REGEX_CASELESS;
+#else   
+    rc.options = caseless ? NGX_REGEX_CASELESS : 0;
+#endif
+
+    if (ngx_regex_compile(&rc) != NGX_OK) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "ngx_regex_compile: %V",
+                            &rc.err);
+        return NGX_ERROR;
+    }
+
+    ucscf->expect_body_regex = rc.regex;
+    return NGX_OK;
+
+#else
+
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                       "using regex \"%V\" requires PCRE library",
+                       regex);
+    return NGX_ERROR;
+
+#endif
+}
+
+ngx_int_t
+ngx_upstream_check_http_parse_status_line(
+    ngx_buf_t *b, ngx_uint_t *pstate, ngx_http_status_t *status)
+{
+    u_char ch, *p;
+    enum {
+        sw_start = 0,
+        sw_H,
+        sw_HT,
+        sw_HTT,
+        sw_HTTP,
+        sw_first_major_digit,
+        sw_major_digit,
+        sw_first_minor_digit,
+        sw_minor_digit,
+        sw_status,
+        sw_space_after_status,
+        sw_status_text,
+        sw_lf,
+        sw_cr,
+        sw_almost_done,
+        receive_body
+    } state;
+
+    state = *pstate;
+
+    if (state == receive_body) {
+        return NGX_OK;
+    }
+
+    for (p = b->pos; p < b->last; p++) {
+        ch = *p;
+
+        switch (state) {
+
+            /* "HTTP/" */
+            case sw_start:
+                if (ch != 'H') {
+                    return NGX_ERROR;
+                }
+
+                state = sw_H;
+                break;
+
+            case sw_H:
+                if (ch != 'T') {
+                    return NGX_ERROR;
+                }
+
+                state = sw_HT;
+                break;
+
+            case sw_HT:
+                if (ch != 'T') {
+                    return NGX_ERROR;
+                }
+
+                state = sw_HTT;
+                break;
+
+            case sw_HTT:
+                if (ch != 'P') {
+                    return NGX_ERROR;
+                }
+
+                state = sw_HTTP;
+                break;
+
+            case sw_HTTP:
+                if (ch != '/') {
+                    return NGX_ERROR;
+                }
+
+                state = sw_first_major_digit;
+                break;
+
+                /* the first digit of major HTTP version */
+            case sw_first_major_digit:
+                if (ch < '1' || ch > '9') {
+                    return NGX_ERROR;
+                }
+
+                state = sw_major_digit;
+                break;
+
+                /* the major HTTP version or dot */
+            case sw_major_digit:
+                if (ch == '.') {
+                    state = sw_first_minor_digit;
+                    break;
+                }
+
+                if (ch < '0' || ch > '9') {
+                    return NGX_ERROR;
+                }
+
+                break;
+
+                /* the first digit of minor HTTP version */
+            case sw_first_minor_digit:
+                if (ch < '0' || ch > '9') {
+                    return NGX_ERROR;
+                }
+
+                state = sw_minor_digit;
+                break;
+
+                /* the minor HTTP version or the end of the request line */
+            case sw_minor_digit:
+                if (ch == ' ') {
+                    state = sw_status;
+                    break;
+                }
+
+                if (ch < '0' || ch > '9') {
+                    return NGX_ERROR;
+                }
+
+                break;
+
+                /* HTTP status code */
+            case sw_status:
+                if (ch == ' ') {
+                    break;
+                }
+
+                if (ch < '0' || ch > '9') {
+                    return NGX_ERROR;
+                }
+
+                status->code = status->code * 10 + ch - '0';
+
+                if (++status->count == 3) {
+                    state = sw_space_after_status;
+                    status->start = p - 2;
+                }
+
+                break;
+
+                /* space or end of line */
+            case sw_space_after_status:
+                switch (ch) {
+                    case ' ':
+                        state = sw_status_text;
+                        break;
+                    case '.':                    /* IIS may send 403.1, 403.2, etc */
+                        state = sw_status_text;
+                        break;
+                    case CR:
+                        state = sw_almost_done;
+                        break;
+                    case LF:
+                        goto done;
+                    default:
+                        return NGX_ERROR;
+                }
+                break;
+
+                /* any text until end of line */
+            case sw_status_text:
+                switch (ch) {
+                    case CR:
+                        state = sw_lf;
+                        break;
+                    case LF:
+                        goto done;
+                }
+                break;
+            /* LF */
+            case sw_lf:
+                switch (ch) {
+                case LF:
+                    state = sw_cr;
+                    break;
+                default:
+                    return NGX_ERROR;
+                }
+                break;
+
+            /* CR */
+            case sw_cr:
+                switch (ch) {
+                case CR: /* second CR */
+                    state = sw_almost_done;
+                    break;
+                default: /* response header */
+                    state = sw_status_text;
+                    break;
+                }
+                break;
+
+            /* LF */
+            case sw_almost_done:
+                switch (ch) {
+                case LF:
+                    /* all header_end */
+                    status->end = p - 1;
+                    goto done;
+                default:
+                    return NGX_ERROR;
+                }
+            case receive_body:
+                return NGX_OK;
+        }
+    }
+
+    // save parsed state.
+    b->pos = p;
+    *pstate = state;
+    return NGX_AGAIN;
+
+    done:
+    // set pos to start of body.
+    b->pos = p + 1;
+
+    if (status->end == NULL) {
+        status->end = p;
+    }
+    *pstate = receive_body;
+
+    return NGX_OK;
+}
+


### PR DESCRIPTION
# usage:
1. check_http_expect_body ~ ".+OK.+";
1. check_http_expect_body ~* ".+Ok.+"; (caseless)

by the way, both http upstream and stream upstream context are supported.
