### PR TITLE
将http_upstream的tcp探针的need_keepalive关闭

### DIFF
--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -549,7 +549,7 @@ static ngx_check_conf_t  ngx_check_types[] = {
       NULL,
       NULL,
       0,
-      1 },
+      0 },
 
     { NGX_HTTP_CHECK_HTTP,
       ngx_string("http"),
@@ -3863,3 +3863,4 @@ ngx_http_upstream_check_init_process(ngx_cycle_t *cycle)
 
     return ngx_http_upstream_check_add_timers(cycle);
 }
+


### PR DESCRIPTION
将http_upstream的tcp探针的need_keepalive关闭。否则当网络突然中断的时候，会导致server无法按预期熔断